### PR TITLE
[BE][DB] DB 연결 후 student mock 데이터 작업 API 기능 구현

### DIFF
--- a/BE/holder/src/config/.test.env
+++ b/BE/holder/src/config/.test.env
@@ -1,1 +1,2 @@
 API_CREATE_USER_VC=http://localhost:8082/api/issuer/create-vc
+API_GET_USER_MAJOR=http://localhost:4000/api/service/get-major

--- a/BE/holder/src/holder/holder-api.service.ts
+++ b/BE/holder/src/holder/holder-api.service.ts
@@ -13,12 +13,15 @@ export class HolderAPIService {
   ) {}
 
   // 사용자가 존재하는지 유효성 검증
-  // TODO: Mock DB 생성 후 연결
   async getUserMajor(dto: UserVCDto): Promise<string> {
     const { stNum, stPwd } = dto;
     // params로 학생의 전공 코드를 DB에서 반환
-    const majorCode = '245';
-    return majorCode;
+    const url = this.configService.get<string>('API_GET_USER_MAJOR');
+    return lastValueFrom(
+      this.httpService
+        .get(url, { params: { stNum, stPwd } })
+        .pipe(map((response) => response.data)),
+    );
   }
 
   // Issuer 호출

--- a/BE/holder/src/main.ts
+++ b/BE/holder/src/main.ts
@@ -11,7 +11,7 @@ async function bootstrap() {
   });
 
   const swaggerConfig = new DocumentBuilder()
-    .setTitle('Service API Docs')
+    .setTitle('HOLDER API Docs')
     .setVersion('1.0')
     .build();
   const document = SwaggerModule.createDocument(app, swaggerConfig);

--- a/BE/issuer/src/issuer/issuer-api.controller.ts
+++ b/BE/issuer/src/issuer/issuer-api.controller.ts
@@ -14,7 +14,7 @@ export class IssuerAPIController {
   // Holder에서 호출
   @Get('/create-vc')
   @ApiOperation({
-    summary: '사용자 VC 생성 후 블록체인에 키체인 적재',
+    summary: 'HOLDER 호출) 사용자 VC 생성 후 블록체인에 키체인 적재',
   })
   async createUserVC(@Query() dto: UserVCDto) {
     const { uuid, vc } = this.issuerAPIService.createUserVC(dto);

--- a/BE/issuer/src/main.ts
+++ b/BE/issuer/src/main.ts
@@ -11,7 +11,7 @@ async function bootstrap() {
   });
 
   const swaggerConfig = new DocumentBuilder()
-    .setTitle('Service API Docs')
+    .setTitle('ISSUER API Docs')
     .setVersion('1.0')
     .build();
   const document = SwaggerModule.createDocument(app, swaggerConfig);

--- a/BE/service/src/config/typeorm.config.ts
+++ b/BE/service/src/config/typeorm.config.ts
@@ -1,6 +1,7 @@
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { HolderVCEntity } from '../entity/holder_vc.entity';
 import { ConfigService } from '@nestjs/config';
+import { StudentEntity } from 'src/entity/student.entity';
 
 export const TypeormConfig = (
   configService: ConfigService,
@@ -11,7 +12,7 @@ export const TypeormConfig = (
   username: configService.get<string>('DB_USERNAME'),
   password: configService.get<string>('DB_PWD'),
   database: 'db',
-  entities: [HolderVCEntity],
+  entities: [HolderVCEntity, StudentEntity],
   synchronize: true,
   logging: true,
 });

--- a/BE/service/src/config/typeorm.config.ts
+++ b/BE/service/src/config/typeorm.config.ts
@@ -13,6 +13,6 @@ export const TypeormConfig = (
   password: configService.get<string>('DB_PWD'),
   database: 'db',
   entities: [HolderVCEntity, StudentEntity],
-  synchronize: true,
+  synchronize: false,
   logging: true,
 });

--- a/BE/service/src/dto/user-info.dto.ts
+++ b/BE/service/src/dto/user-info.dto.ts
@@ -1,0 +1,9 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class UserInfoDto {
+  @ApiProperty({ description: '학번' })
+  readonly stNum: string;
+
+  @ApiProperty({ description: '비밀번호' })
+  readonly stPwd: string;
+}

--- a/BE/service/src/entity/student.entity.ts
+++ b/BE/service/src/entity/student.entity.ts
@@ -1,0 +1,13 @@
+import { Entity, Column, PrimaryColumn } from 'typeorm';
+
+@Entity({ name: 'student' })
+export class StudentEntity {
+  @PrimaryColumn({ type: 'varchar' })
+  number: string;
+
+  @Column({ type: 'varchar' })
+  password: string;
+
+  @Column({ type: 'varchar' })
+  major_code: string;
+}

--- a/BE/service/src/main.ts
+++ b/BE/service/src/main.ts
@@ -11,7 +11,7 @@ async function bootstrap() {
   });
 
   const swaggerConfig = new DocumentBuilder()
-    .setTitle('Service API Docs')
+    .setTitle('SERVICE API Docs')
     .setVersion('1.0')
     .build();
   const document = SwaggerModule.createDocument(app, swaggerConfig);

--- a/BE/service/src/service/service-api.controller.ts
+++ b/BE/service/src/service/service-api.controller.ts
@@ -5,6 +5,7 @@ import { ProofDto } from '../dto/proof.dto';
 import { UserVCDto } from '../dto/user-vc.dto';
 import { CustomExceptionFilter } from '../filter/exception.filter';
 import { CustomErrorException } from '../filter/custom-error.exception';
+import { UserInfoDto } from 'src/dto/user-info.dto';
 
 @Controller('api/service')
 @ApiTags('SERVICE API')
@@ -18,6 +19,19 @@ export class ServiceAPIController {
   })
   async verifyProof(@Query() dto: ProofDto): Promise<boolean> {
     return await this.serviceAPIService.verifyProof(dto);
+  }
+
+  // Holder에서 호출
+  @Get('get-major')
+  @ApiOperation({
+    summary: '학생 정보로 전공 코드를 반환',
+  })
+  async getUserMajot(@Query() dto: UserInfoDto): Promise<string> {
+    const res = await this.serviceAPIService.getUserMajor(dto);
+    if (!res) {
+      return '';
+    }
+    return res.major_code;
   }
 
   // Issuer에서 호출

--- a/BE/service/src/service/service-api.controller.ts
+++ b/BE/service/src/service/service-api.controller.ts
@@ -24,7 +24,7 @@ export class ServiceAPIController {
   // Holder에서 호출
   @Get('get-major')
   @ApiOperation({
-    summary: '학생 정보로 전공 코드를 반환',
+    summary: 'HOLDER 호출) 학생 정보로 전공 코드를 반환',
   })
   async getUserMajot(@Query() dto: UserInfoDto): Promise<string> {
     const res = await this.serviceAPIService.getUserMajor(dto);
@@ -37,7 +37,7 @@ export class ServiceAPIController {
   // Issuer에서 호출
   @Post('save-vc')
   @ApiOperation({
-    summary: 'Issuer가 생성한 Holder VC를 DB에 저장',
+    summary: 'ISSUER 호출) Issuer가 생성한 Holder VC를 DB에 저장',
   })
   async saveUserVC(@Body() dto: UserVCDto) {
     try {
@@ -51,7 +51,7 @@ export class ServiceAPIController {
   //! Init API
   @Post('init-mock')
   @ApiOperation({
-    summary: 'student 테이블의 데이터 mocking',
+    summary: 'INIT 주의) student 테이블의 데이터 mocking',
   })
   async initMock() {
     try {

--- a/BE/service/src/service/service-api.controller.ts
+++ b/BE/service/src/service/service-api.controller.ts
@@ -33,4 +33,17 @@ export class ServiceAPIController {
       throw new CustomErrorException('VC Save Failed', 500);
     }
   }
+
+  //! Init API
+  @Post('init-mock')
+  @ApiOperation({
+    summary: 'student 테이블의 데이터 mocking',
+  })
+  async initMock() {
+    try {
+      return await this.serviceAPIService.initMock();
+    } catch (error) {
+      throw new CustomErrorException('Init Mock Failed', 500);
+    }
+  }
 }

--- a/BE/service/src/service/service-api.module.ts
+++ b/BE/service/src/service/service-api.module.ts
@@ -4,9 +4,13 @@ import { ServiceAPIService } from './service-api.service';
 import { HttpModule } from '@nestjs/axios';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { HolderVCEntity } from '../entity/holder_vc.entity';
+import { StudentEntity } from 'src/entity/student.entity';
 
 @Module({
-  imports: [HttpModule, TypeOrmModule.forFeature([HolderVCEntity])],
+  imports: [
+    HttpModule,
+    TypeOrmModule.forFeature([HolderVCEntity, StudentEntity]),
+  ],
   controllers: [ServiceAPIController],
   providers: [ServiceAPIService],
 })

--- a/BE/service/src/service/service-api.service.ts
+++ b/BE/service/src/service/service-api.service.ts
@@ -9,6 +9,7 @@ import { Repository } from 'typeorm';
 import { StudentEntity } from 'src/entity/student.entity';
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { UserInfoDto } from 'src/dto/user-info.dto';
 
 @Injectable()
 export class ServiceAPIService {
@@ -21,11 +22,6 @@ export class ServiceAPIService {
     private readonly configService: ConfigService,
   ) {}
 
-  async saveUserVC(uuid: string, vc: string) {
-    await this.holderVCRepository.save({ did: uuid, vc });
-    return;
-  }
-
   // Verfier API 호출
   async verifyProof(dto: ProofDto): Promise<boolean> {
     const url = this.configService.get<string>('API_VERIFY_PROOF');
@@ -34,6 +30,20 @@ export class ServiceAPIService {
         .get(url, { params: { ...dto } })
         .pipe(map((response) => response.data)),
     );
+  }
+
+  async getUserMajor(dto: UserInfoDto): Promise<StudentEntity> {
+    const { stNum, stPwd } = dto;
+    return await this.studentRepository
+      .createQueryBuilder('student')
+      .where('student.number = :stNum', { stNum })
+      .andWhere('student.password = :stPwd', { stPwd })
+      .getOne();
+  }
+
+  async saveUserVC(uuid: string, vc: string) {
+    await this.holderVCRepository.save({ did: uuid, vc });
+    return;
   }
 
   // config 폴더의 mock data를 DB에 삽입

--- a/BE/verifier/src/main.ts
+++ b/BE/verifier/src/main.ts
@@ -11,7 +11,7 @@ async function bootstrap() {
   });
 
   const swaggerConfig = new DocumentBuilder()
-    .setTitle('Service API Docs')
+    .setTitle('VERIFIER API Docs')
     .setVersion('1.0')
     .build();
   const document = SwaggerModule.createDocument(app, swaggerConfig);

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,3 +23,18 @@ services:
     image: service
     ports:
       - "4000:4000"
+    depends_on:
+      - mysql
+
+  mysql:
+    image: mysql:8.0
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_ROOT_PASSWORD: 1111
+      MYSQL_DATABASE: db
+    volumes:
+      - mysql-data:/var/lib/mysql
+
+volumes:
+  mysql-data:


### PR DESCRIPTION
## 관련 이슈

없음

## 작업 단계

- [x] docker로 MySQL 생성
- [x] TypeORMConfig로 DB 연결
- [x] 필요한 StudentEntity 생성
- [x] mock data 생성 API 구현 후 테스팅
- [x] 존재하지 않는 사용자 에러 처리
- [x] e2e 테스트 완료 (VC 생성 후 블록체인에 배포 후 DB 저장)

## 설명

docker를 통해 DB 생성 및 swagger API 호출로 mock data 초기화 가능 (student table)
createUserVC API e2e 테스트 완료 및 에러 처리 구현
