### PR TITLE
[HOTFIX][BE] get-user-info 에러 수정

### DIFF
--- a/BE/service/src/api/service/service-api.service.ts
+++ b/BE/service/src/api/service/service-api.service.ts
@@ -77,7 +77,7 @@ export class ServiceAPIService {
       return { statusCode: 400, data: { message: 'Password is not match' } };
     }
 
-    const payload = { userId: userRow.pk };
+    const payload = { pk: userRow.pk };
     const token = await this.jwtService.signAsync(payload);
     const { pk, nickname } = userRow;
     return { statusCode: 200, data: { token, nickname, userPk: pk } };


### PR DESCRIPTION
- get-user-info 요청 시 디비 상 제일 첫 번째 칼럼의 유저 정보만 가져와지는 에러 해결
- 발급된 jwt 토큰을 해시했을 때, key 값이 일치하지 않아서 발생한 문제